### PR TITLE
use correct repo name in lazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Plug "salesforce.nvim"
 
 ```lua
 {
-    "salesforce.nvim",
+    "jonathanmorris180/salesforce.nvim",
     dependencies = {
         "nvim-lua/plenary.nvim",
         "nvim-treesitter/nvim-treesitter",


### PR DESCRIPTION
## 📃 Summary

Use "jonathanmorris180/salesforce.nvim" rather than "salesforce.nvim" in Lazy.

I assume this change applies to other package managers too despite I don't use them.


