### PR TITLE
fix: add sf cli executable based on os

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ require("salesforce").setup({
     org_manager = {
         default_org_indicator = "󰄬",
     },
+    -- Default SF CLI executable (should not need to be changed)
+    sf_executable = "sf",
 })
 ```
 

--- a/doc/salesforce.txt
+++ b/doc/salesforce.txt
@@ -47,6 +47,8 @@ You can pass in a lua table of options to customize the plugin. The default opti
     org_manager = {
         default_org_indicator = "󰄬",
     },
+    -- Default SF CLI executable is SF (should not need to be changed)
+    sf_executable = "sf",
 }
 <
 

--- a/lua/salesforce/config.lua
+++ b/lua/salesforce/config.lua
@@ -24,7 +24,7 @@ function Config:new()
         org_manager = {
             default_org_indicator = "󰄬",
         },
-        -- Default SF CLI executable is SF but for Windows it is using npm's SF.cmd
+        -- Default SF CLI executable (should not need to be changed)
         sf_executable = "sf",
     }
 

--- a/lua/salesforce/config.lua
+++ b/lua/salesforce/config.lua
@@ -24,7 +24,14 @@ function Config:new()
         org_manager = {
             default_org_indicator = "󰄬",
         },
+        -- Default SF CLI executable is SF but for Windows it is using npm's SF.cmd
+        sf_executable = "sf",
     }
+
+    if jit.os == "Windows" then
+        o.options.sf_executable = "sf.cmd"
+    end
+
     return o
 end
 

--- a/lua/salesforce/diff.lua
+++ b/lua/salesforce/diff.lua
@@ -15,6 +15,7 @@ end
 local M = {}
 
 local temp_dir
+local executable = Config:get_options().sf_executable
 
 local function diff_callback(j)
     vim.schedule(function()
@@ -76,7 +77,7 @@ local function execute_job(command)
     local args = Util.split(command, " ")
     table.remove(args, 1)
     local new_job = Job:new({
-        command = Config:get_options().sf_executable,
+        command = executable,
         args = args,
         on_exit = diff_callback,
         env = { HOME = vim.env.HOME, PATH = vim.env.PATH },
@@ -120,10 +121,15 @@ M.diff_with_org = function()
     vim.fn.mkdir(temp_dir_with_suffix, "p")
     Debug:log("diff.lua", "Created temp dir: " .. temp_dir)
 
-    local sf = Config:get_options().sf_executable
-        .. " project retrieve start -m %s:%s -r %s -o %s --json"
+    local command = string.format(
+        "%s project retrieve start -m %s:%s -r %s -o %s --json",
+        executable,
+        metadataType,
+        file_name_no_ext,
+        temp_dir,
+        default_username
+    )
 
-    local command = string.format(sf, metadataType, file_name_no_ext, temp_dir, default_username)
     Debug:log("diff.lua", "Command: " .. command)
     execute_job(command)
 end

--- a/lua/salesforce/diff.lua
+++ b/lua/salesforce/diff.lua
@@ -2,6 +2,7 @@ local Util = require("salesforce.util")
 local Job = require("plenary.job")
 local Debug = require("salesforce.debug")
 local OrgManager = require("salesforce.org_manager")
+local Config = require("salesforce.config")
 
 function Job:is_running()
     if self.handle and not vim.loop.is_closing(self.handle) and vim.loop.is_active(self.handle) then
@@ -75,7 +76,7 @@ local function execute_job(command)
     local args = Util.split(command, " ")
     table.remove(args, 1)
     local new_job = Job:new({
-        command = "sf",
+        command = Config:get_options().sf_executable,
         args = args,
         on_exit = diff_callback,
         env = { HOME = vim.env.HOME, PATH = vim.env.PATH },
@@ -119,13 +120,10 @@ M.diff_with_org = function()
     vim.fn.mkdir(temp_dir_with_suffix, "p")
     Debug:log("diff.lua", "Created temp dir: " .. temp_dir)
 
-    local command = string.format(
-        "sf project retrieve start -m %s:%s -r %s -o %s --json",
-        metadataType,
-        file_name_no_ext,
-        temp_dir,
-        default_username
-    )
+    local sf = Config:get_options().sf_executable
+        .. " project retrieve start -m %s:%s -r %s -o %s --json"
+
+    local command = string.format(sf, metadataType, file_name_no_ext, temp_dir, default_username)
     Debug:log("diff.lua", "Command: " .. command)
     execute_job(command)
 end

--- a/lua/salesforce/execute_anon.lua
+++ b/lua/salesforce/execute_anon.lua
@@ -3,6 +3,7 @@ local Debug = require("salesforce.debug")
 local OrgManager = require("salesforce.org_manager")
 local Job = require("plenary.job")
 local Util = require("salesforce.util")
+local Config = require("salesforce.config")
 
 function Job:is_running()
     if self.handle and not vim.loop.is_closing(self.handle) and vim.loop.is_active(self.handle) then
@@ -35,7 +36,7 @@ M.execute_anon = function()
     local command = string.format("sf apex run -f '%s' -o %s", path, default_username)
     Debug:log("execute_anon.lua", "Running " .. command .. "...")
     local new_job = Job:new({
-        command = "sf",
+        command = Config:get_options().sf_executable,
         env = { HOME = vim.env.HOME, PATH = vim.env.PATH },
         args = { "apex", "run", "-f", path, "-o", default_username },
         on_exit = function(j, code)

--- a/lua/salesforce/execute_anon.lua
+++ b/lua/salesforce/execute_anon.lua
@@ -33,10 +33,11 @@ M.execute_anon = function()
 
     Popup:create_popup({})
     Popup:write_to_popup("Executing anonymous Apex script...")
-    local command = string.format("sf apex run -f '%s' -o %s", path, default_username)
+    local executable = Config:get_options().sf_executable
+    local command = string.format("%s apex run -f '%s' -o %s", executable, path, default_username)
     Debug:log("execute_anon.lua", "Running " .. command .. "...")
     local new_job = Job:new({
-        command = Config:get_options().sf_executable,
+        command = executable,
         env = { HOME = vim.env.HOME, PATH = vim.env.PATH },
         args = { "apex", "run", "-f", path, "-o", default_username },
         on_exit = function(j, code)

--- a/lua/salesforce/file_manager.lua
+++ b/lua/salesforce/file_manager.lua
@@ -126,7 +126,7 @@ local function push(command, path)
     table.insert(args, "-d")
     table.insert(args, path)
     local new_job = Job:new({
-        command = "sf",
+        command = Config:get_options().sf_executable,
         env = { HOME = vim.env.HOME, PATH = vim.env.PATH },
         args = args,
         on_exit = push_to_org_callback,
@@ -151,7 +151,7 @@ local function pull(command, path)
     table.insert(args, "-d")
     table.insert(args, path)
     local new_job = Job:new({
-        command = "sf",
+        command = Config:get_options().sf_executable,
         env = { HOME = vim.env.HOME, PATH = vim.env.PATH },
         args = args,
         on_exit = pull_from_org_callback,

--- a/lua/salesforce/file_manager.lua
+++ b/lua/salesforce/file_manager.lua
@@ -14,6 +14,8 @@ end
 
 local M = {}
 
+local executable = Config:get_options().sf_executable
+
 local function push_to_org_callback(j)
     vim.schedule(function()
         local sfdx_output = j:result()
@@ -126,7 +128,7 @@ local function push(command, path)
     table.insert(args, "-d")
     table.insert(args, path)
     local new_job = Job:new({
-        command = Config:get_options().sf_executable,
+        command = executable,
         env = { HOME = vim.env.HOME, PATH = vim.env.PATH },
         args = args,
         on_exit = push_to_org_callback,
@@ -151,7 +153,7 @@ local function pull(command, path)
     table.insert(args, "-d")
     table.insert(args, path)
     local new_job = Job:new({
-        command = Config:get_options().sf_executable,
+        command = executable,
         env = { HOME = vim.env.HOME, PATH = vim.env.PATH },
         args = args,
         on_exit = pull_from_org_callback,
@@ -181,7 +183,8 @@ M.push_to_org = function()
     end
 
     Util.clear_and_notify(string.format("Pushing %s to org %s...", file_name, default_username))
-    local command = string.format("sf project deploy start --json -o %s", default_username)
+    local command =
+        string.format("%s project deploy start --json -o %s", executable, default_username)
     Debug:log("file_manager.lua", "Command: " .. command .. string.format(" -d '%s'", path))
     push(command, path)
 end
@@ -197,7 +200,8 @@ M.pull_from_org = function()
     end
 
     Util.clear_and_notify(string.format("Pulling %s from org %s...", file_name, default_username))
-    local command = string.format("sf project retrieve start --json -o %s", default_username)
+    local command =
+        string.format("%s project retrieve start --json -o %s", executable, default_username)
     if Config:get_options().file_manager.ignore_conflicts then
         Debug:log("file_manager.lua", "Ignoring conflicts becuase of config option")
         command = command .. " --ignore-conflicts"

--- a/lua/salesforce/init.lua
+++ b/lua/salesforce/init.lua
@@ -43,6 +43,8 @@
 ---     org_manager = {
 ---         default_org_indicator = "󰄬",
 ---     },
+---     -- Default SF CLI executable (should not need to be changed)
+---     sf_executable = "sf",
 --- }
 --- <
 local Config = require("salesforce.config")

--- a/lua/salesforce/org_manager.lua
+++ b/lua/salesforce/org_manager.lua
@@ -80,7 +80,7 @@ function OrgManager:get_org_info(add_log)
     local args = Util.split(command, " ")
     table.remove(args, 1)
     local new_job = Job:new({
-        command = "sf",
+        command = Config:get_options().sf_executable,
         args = args,
         on_exit = function(j)
             vim.schedule(function()
@@ -129,7 +129,7 @@ function OrgManager:select_org()
     local args = Util.split(command, " ")
     table.remove(args, 1)
     local new_job = Job:new({
-        command = "sf",
+        command = Config:get_options().sf_executable,
         args = args,
         on_exit = function(j)
             vim.schedule(function()

--- a/lua/salesforce/org_manager.lua
+++ b/lua/salesforce/org_manager.lua
@@ -14,6 +14,7 @@ function Job:is_running()
 end
 
 local OrgManager = {}
+local executable = Config:get_options().sf_executable
 
 function OrgManager:new()
     local o = {}
@@ -75,12 +76,12 @@ function OrgManager:command_in_progress()
 end
 
 function OrgManager:get_org_info(add_log)
-    local command = "sf org list --json"
+    local command = string.format("%s org list --json", executable)
     Debug:log("org_manager.lua", "Executing command: %s", command)
     local args = Util.split(command, " ")
     table.remove(args, 1)
     local new_job = Job:new({
-        command = Config:get_options().sf_executable,
+        command = executable,
         args = args,
         on_exit = function(j)
             vim.schedule(function()
@@ -123,13 +124,13 @@ function OrgManager:select_org()
     local idx = vim.fn.line(".") - 2
     local org_alias = self.orgs[idx].alias
     local org_username = self.orgs[idx].username
-    local command = string.format("sf config set target-org %s --json", org_username)
+    local command = string.format("%s config set target-org %s --json", executable, org_username)
     Debug:log("org_manager.lua", "Selected org: " .. org_alias)
     Debug:log("org_manager.lua", "Executing command: %s", command)
     local args = Util.split(command, " ")
     table.remove(args, 1)
     local new_job = Job:new({
-        command = Config:get_options().sf_executable,
+        command = executable,
         args = args,
         on_exit = function(j)
             vim.schedule(function()

--- a/lua/salesforce/test_runner.lua
+++ b/lua/salesforce/test_runner.lua
@@ -4,9 +4,12 @@ local OrgManager = require("salesforce.org_manager")
 local Debug = require("salesforce.debug")
 local Treesitter = require("salesforce.treesitter")
 local Util = require("salesforce.util")
+local Config = require("salesforce.config")
 
-local run_class_command = 'sf apex run test -n "%s" --synchronous -r human -o %s'
-local run_method_command = 'sf apex run test -t "%s.%s" --synchronous -r human -o %s'
+local run_class_command = Config:get_options().sf_executable
+    .. ' apex run test -n "%s" --synchronous -r human -o %s'
+local run_method_command = Config:get_options().sf_executable
+    .. ' apex run test -t "%s.%s" --synchronous -r human -o %s'
 
 local M = {}
 
@@ -38,7 +41,7 @@ local function execute_job(command)
     local args = Util.split(command, " ")
     table.remove(args, 1)
     local new_job = Job:new({
-        command = "sf",
+        command = Config:get_options().sf_executable,
         env = { HOME = vim.env.HOME, PATH = vim.env.PATH },
         args = args,
         on_exit = function(j, code)

--- a/lua/salesforce/test_runner.lua
+++ b/lua/salesforce/test_runner.lua
@@ -6,10 +6,9 @@ local Treesitter = require("salesforce.treesitter")
 local Util = require("salesforce.util")
 local Config = require("salesforce.config")
 
-local run_class_command = Config:get_options().sf_executable
-    .. ' apex run test -n "%s" --synchronous -r human -o %s'
-local run_method_command = Config:get_options().sf_executable
-    .. ' apex run test -t "%s.%s" --synchronous -r human -o %s'
+local executable = Config:get_options().sf_executable
+local run_class_command = executable .. ' apex run test -n "%s" --synchronous -r human -o %s'
+local run_method_command = executable .. ' apex run test -t "%s.%s" --synchronous -r human -o %s'
 
 local M = {}
 
@@ -41,7 +40,7 @@ local function execute_job(command)
     local args = Util.split(command, " ")
     table.remove(args, 1)
     local new_job = Job:new({
-        command = Config:get_options().sf_executable,
+        command = executable,
         env = { HOME = vim.env.HOME, PATH = vim.env.PATH },
         args = args,
         on_exit = function(j, code)


### PR DESCRIPTION
## 📃 Summary
Adding `vim.env.HOME` and `vim.env.PATH` is the way but on Windows SF command is not recognized by Plenary. The solution is to provide exact command from npm, for linux based system it is just `sf` but for Windows this command should be `sf.cmd`.

This pull request adds additional variable to plugin configuration where default value is `sf` but when jit detects that this is Windows os this variable is set to `sf.cmd`. This resolves https://github.com/jonathanmorris180/salesforce.nvim/issues/13 issue.
