### PR TITLE
Propagate proxy settings to plenary jobs

### DIFF
--- a/lua/salesforce/diff.lua
+++ b/lua/salesforce/diff.lua
@@ -91,7 +91,7 @@ local function execute_job(args)
         command = executable,
         args = all_args,
         on_exit = diff_callback,
-        env = { HOME = vim.env.HOME, PATH = vim.env.PATH },
+        env = Util.get_env(),
         on_stderr = function(_, data)
             vim.schedule(function()
                 Debug:log("diff.lua", "Command stderr is: %s", data)

--- a/lua/salesforce/execute_anon.lua
+++ b/lua/salesforce/execute_anon.lua
@@ -40,7 +40,7 @@ M.execute_anon = function()
     Debug:log("execute_anon.lua", "Running " .. command .. "...")
     local new_job = Job:new({
         command = executable,
-        env = { HOME = vim.env.HOME, PATH = vim.env.PATH },
+        env = Util:get_env(),
         args = { "apex", "run", "-f", path, "-o", default_username },
         on_exit = function(j, code)
             vim.schedule(function()

--- a/lua/salesforce/execute_anon.lua
+++ b/lua/salesforce/execute_anon.lua
@@ -40,7 +40,7 @@ M.execute_anon = function()
     Debug:log("execute_anon.lua", "Running " .. command .. "...")
     local new_job = Job:new({
         command = executable,
-        env = Util:get_env(),
+        env = Util.get_env(),
         args = { "apex", "run", "-f", path, "-o", default_username },
         on_exit = function(j, code)
             vim.schedule(function()

--- a/lua/salesforce/file_manager.lua
+++ b/lua/salesforce/file_manager.lua
@@ -129,7 +129,7 @@ local function push(command, path)
     table.insert(args, path)
     local new_job = Job:new({
         command = executable,
-        env = { HOME = vim.env.HOME, PATH = vim.env.PATH, HTTP_PROXY = vim.env.HTTP_PROXY, HTTPS_PROXY = vim.env.HTTPS_PROXY },
+        env = Util.get_env(),
         args = args,
         on_exit = push_to_org_callback,
         on_stderr = function(_, data)
@@ -154,7 +154,7 @@ local function pull(command, path)
     table.insert(args, path)
     local new_job = Job:new({
         command = executable,
-        env = { HOME = vim.env.HOME, PATH = vim.env.PATH, HTTP_PROXY = vim.env.HTTP_PROXY, HTTPS_PROXY = vim.env.HTTPS_PROXY },
+        env = Util.get_env(),
         args = args,
         on_exit = pull_from_org_callback,
         on_stderr = function(_, data)

--- a/lua/salesforce/file_manager.lua
+++ b/lua/salesforce/file_manager.lua
@@ -129,7 +129,7 @@ local function push(command, path)
     table.insert(args, path)
     local new_job = Job:new({
         command = executable,
-        env = { HOME = vim.env.HOME, PATH = vim.env.PATH },
+        env = { HOME = vim.env.HOME, PATH = vim.env.PATH, HTTP_PROXY = vim.env.HTTP_PROXY, HTTPS_PROXY = vim.env.HTTPS_PROXY },
         args = args,
         on_exit = push_to_org_callback,
         on_stderr = function(_, data)
@@ -154,7 +154,7 @@ local function pull(command, path)
     table.insert(args, path)
     local new_job = Job:new({
         command = executable,
-        env = { HOME = vim.env.HOME, PATH = vim.env.PATH },
+        env = { HOME = vim.env.HOME, PATH = vim.env.PATH, HTTP_PROXY = vim.env.HTTP_PROXY, HTTPS_PROXY = vim.env.HTTPS_PROXY },
         args = args,
         on_exit = pull_from_org_callback,
         on_stderr = function(_, data)

--- a/lua/salesforce/org_manager.lua
+++ b/lua/salesforce/org_manager.lua
@@ -100,7 +100,7 @@ function OrgManager:get_org_info(add_log)
                 self:parse_orgs(sfdx_response)
             end)
         end,
-        env = { HOME = vim.env.HOME, PATH = vim.env.PATH },
+        env = Util.get_env(),
         on_stderr = function(_, data)
             vim.schedule(function()
                 Debug:log("org_manager.lua", "Command stderr is: %s", data)
@@ -170,7 +170,7 @@ function OrgManager:select_org()
                 end
             end)
         end,
-        env = { HOME = vim.env.HOME, PATH = vim.env.PATH },
+        env = Util.get_env(),
         on_stderr = function(_, data)
             vim.schedule(function()
                 Debug:log("org_manager.lua", "Command stderr is: %s", data)

--- a/lua/salesforce/test_runner.lua
+++ b/lua/salesforce/test_runner.lua
@@ -41,7 +41,7 @@ local function execute_job(command)
     table.remove(args, 1)
     local new_job = Job:new({
         command = executable,
-        env = { HOME = vim.env.HOME, PATH = vim.env.PATH },
+        env = Util.get_env(),
         args = args,
         on_exit = function(j, code)
             vim.schedule(function()

--- a/lua/salesforce/util.lua
+++ b/lua/salesforce/util.lua
@@ -94,7 +94,7 @@ function M.get_env()
         HOME = vim.env.HOME,
         PATH = vim.env.PATH,
         HTTP_PROXY = vim.env.HTTP_PROXY,
-        HTTPS_PROXY = vim.env.HTTPS_PROXY
+        HTTPS_PROXY = vim.env.HTTPS_PROXY,
     }
 end
 

--- a/lua/salesforce/util.lua
+++ b/lua/salesforce/util.lua
@@ -89,4 +89,13 @@ function M.split(inputstr, sep)
     return t
 end
 
+function M.get_env()
+    return {
+        HOME = vim.env.HOME,
+        PATH = vim.env.PATH,
+        HTTP_PROXY = vim.env.HTTP_PROXY,
+        HTTPS_PROXY = vim.env.HTTPS_PROXY
+    }
+end
+
 return M


### PR DESCRIPTION
## 📃 Summary

Salesforce cannot execute any request when working behind corporate proxy. Propagating proxy environment variables to plenary jobs fixes the issue.