### PR TITLE
Allow orgs without aliases to be set

### DIFF
--- a/lua/salesforce/debug.lua
+++ b/lua/salesforce/debug.lua
@@ -45,7 +45,7 @@ function Debugger:log(scope, item, ...)
         or (type(item) == "string" and string.format(item, ...))
 
     local debug_str =
-        string.format("[salesforce:%s %s in %s] > %s", os.date("%H:%M:%S"), line, scope, final_arg)
+        string.format("[salesforce:%s %s in %s] > %s", os.date("%c"), line, scope, final_arg)
     self:log_str(debug_str)
 end
 

--- a/lua/salesforce/diff.lua
+++ b/lua/salesforce/diff.lua
@@ -27,7 +27,7 @@ local function diff_callback(j)
 
         local json_ok, sfdx_response = pcall(vim.json.decode, sfdx_output)
         if not json_ok or not sfdx_response then
-            vim.notify("Failed to parse the SFDX command output", vim.log.levels.ERROR)
+            vim.notify("Failed to parse the 'diff' SFDX command output", vim.log.levels.ERROR)
             vim.fn.delete(temp_dir, "rf")
             return
         end

--- a/lua/salesforce/file_manager.lua
+++ b/lua/salesforce/file_manager.lua
@@ -26,7 +26,7 @@ local function push_to_org_callback(j)
 
         local json_ok, sfdx_response = pcall(vim.json.decode, sfdx_output)
         if not json_ok or not sfdx_response then
-            vim.notify("Failed to parse the SFDX command output", vim.log.levels.ERROR)
+            vim.notify("Failed to parse the 'push to org' SFDX command output", vim.log.levels.ERROR)
             return
         end
 
@@ -78,7 +78,7 @@ local function pull_from_org_callback(j)
 
         local json_ok, sfdx_response = pcall(vim.json.decode, sfdx_output)
         if not json_ok or not sfdx_response then
-            vim.notify("Failed to parse the SFDX command output", vim.log.levels.ERROR)
+            vim.notify("Failed to parse the 'pull from org' SFDX command output", vim.log.levels.ERROR)
             return
         end
 

--- a/lua/salesforce/file_manager.lua
+++ b/lua/salesforce/file_manager.lua
@@ -26,7 +26,10 @@ local function push_to_org_callback(j)
 
         local json_ok, sfdx_response = pcall(vim.json.decode, sfdx_output)
         if not json_ok or not sfdx_response then
-            vim.notify("Failed to parse the 'push to org' SFDX command output", vim.log.levels.ERROR)
+            vim.notify(
+                "Failed to parse the 'push to org' SFDX command output",
+                vim.log.levels.ERROR
+            )
             return
         end
 
@@ -78,7 +81,10 @@ local function pull_from_org_callback(j)
 
         local json_ok, sfdx_response = pcall(vim.json.decode, sfdx_output)
         if not json_ok or not sfdx_response then
-            vim.notify("Failed to parse the 'pull from org' SFDX command output", vim.log.levels.ERROR)
+            vim.notify(
+                "Failed to parse the 'pull from org' SFDX command output",
+                vim.log.levels.ERROR
+            )
             return
         end
 

--- a/lua/salesforce/init.lua
+++ b/lua/salesforce/init.lua
@@ -48,6 +48,7 @@
 --- }
 --- <
 local Config = require("salesforce.config")
+local OrgManager = require("salesforce.org_manager")
 
 local Salesforce = {}
 
@@ -58,6 +59,7 @@ local Salesforce = {}
 ---@usage `require("salesforce").setup({})`
 function Salesforce.setup(opts)
     Salesforce.config = Config:setup(opts)
+    OrgManager:get_org_info(true)
 end
 
 return Salesforce

--- a/lua/salesforce/org_manager.lua
+++ b/lua/salesforce/org_manager.lua
@@ -20,7 +20,6 @@ function OrgManager:new()
     local o = {}
     setmetatable(o, self)
     self.__index = self
-    self:get_org_info(false)
     return o
 end
 
@@ -75,7 +74,7 @@ function OrgManager:command_in_progress()
     end
 end
 
-function OrgManager:get_org_info(add_log)
+function OrgManager:get_org_info(add_success_message)
     local command = string.format("%s org list --json", executable)
     Debug:log("org_manager.lua", "Executing command: %s", command)
     local args = Util.split(command, " ")
@@ -91,10 +90,10 @@ function OrgManager:get_org_info(add_log)
                 Debug:log("org_manager.lua", sfdx_output)
                 local json_ok, sfdx_response = pcall(vim.json.decode, sfdx_output)
                 if not json_ok or not sfdx_response then
-                    vim.notify("Failed to parse the SFDX command output", vim.log.levels.ERROR)
+                    vim.notify("Failed to parse the 'org list' SFDX command output", vim.log.levels.ERROR)
                     return
                 end
-                if add_log then
+                if add_success_message then
                     Util.clear_and_notify("Successfully refreshed org info")
                 end
                 self:parse_orgs(sfdx_response)
@@ -140,7 +139,7 @@ function OrgManager:select_org()
                 Debug:log("org_manager.lua", sfdx_output)
                 local json_ok, sfdx_response = pcall(vim.json.decode, sfdx_output)
                 if not json_ok or not sfdx_response then
-                    vim.notify("Failed to parse the SFDX command output", vim.log.levels.ERROR)
+                    vim.notify("Failed to parse the 'config set target-org' SFDX command output", vim.log.levels.ERROR)
                     return
                 end
 

--- a/lua/salesforce/org_manager.lua
+++ b/lua/salesforce/org_manager.lua
@@ -50,7 +50,7 @@ function OrgManager:get_default_alias()
     end
     for _, org in ipairs(self.orgs) do
         if org.isDefaultUsername then
-            return org.alias
+            return org.alias or org.username
         end
     end
 end
@@ -90,7 +90,10 @@ function OrgManager:get_org_info(add_success_message)
                 Debug:log("org_manager.lua", sfdx_output)
                 local json_ok, sfdx_response = pcall(vim.json.decode, sfdx_output)
                 if not json_ok or not sfdx_response then
-                    vim.notify("Failed to parse the 'org list' SFDX command output", vim.log.levels.ERROR)
+                    vim.notify(
+                        "Failed to parse the 'org list' SFDX command output",
+                        vim.log.levels.ERROR
+                    )
                     return
                 end
                 if add_success_message then
@@ -123,8 +126,9 @@ function OrgManager:select_org()
     local idx = vim.fn.line(".") - 2
     local org_alias = self.orgs[idx].alias
     local org_username = self.orgs[idx].username
+    local org_alias_or_username = org_alias or org_username
     local command = string.format("%s config set target-org %s --json", executable, org_username)
-    Debug:log("org_manager.lua", "Selected org: " .. org_alias)
+    Debug:log("org_manager.lua", "Selected org: " .. org_alias_or_username)
     Debug:log("org_manager.lua", "Executing command: %s", command)
     local args = Util.split(command, " ")
     table.remove(args, 1)
@@ -139,7 +143,10 @@ function OrgManager:select_org()
                 Debug:log("org_manager.lua", sfdx_output)
                 local json_ok, sfdx_response = pcall(vim.json.decode, sfdx_output)
                 if not json_ok or not sfdx_response then
-                    vim.notify("Failed to parse the 'config set target-org' SFDX command output", vim.log.levels.ERROR)
+                    vim.notify(
+                        "Failed to parse the 'config set target-org' SFDX command output",
+                        vim.log.levels.ERROR
+                    )
                     return
                 end
 
@@ -161,8 +168,8 @@ function OrgManager:select_org()
                 then
                     Util.clear_and_notify(
                         string.format(
-                            "Successully set target-org to %s. Refreshing org info...",
-                            org_alias
+                            "Successfully set target-org to %s. Refreshing org info...",
+                            org_alias_or_username
                         )
                     )
                     self:get_org_info(true)
@@ -202,7 +209,9 @@ function OrgManager:set_default_org()
 
     for _, org in ipairs(self.orgs) do
         local default = org.isDefaultUsername and default_org_indicator or ""
-        Popup:append_to_popup(string.format("%s (%s) %s", org.alias, org.username, default))
+        Popup:append_to_popup(
+            string.format("%s (%s) %s", org.alias or "NO ALIAS SET", org.username, default)
+        )
     end
 end
 

--- a/lua/salesforce/util.lua
+++ b/lua/salesforce/util.lua
@@ -79,7 +79,7 @@ function M.get_file_name_without_extension(fileName)
 end
 
 function M.split(inputstr, sep)
-    return vim.split(inputstr, sep, {trimempty = true})
+    return vim.split(inputstr, sep, { trimempty = true })
 end
 
 function M.get_env()

--- a/lua/salesforce/util.lua
+++ b/lua/salesforce/util.lua
@@ -79,14 +79,7 @@ function M.get_file_name_without_extension(fileName)
 end
 
 function M.split(inputstr, sep)
-    if sep == nil then
-        sep = "%s"
-    end
-    local t = {}
-    for str in string.gmatch(inputstr, "([^" .. sep .. "]+)") do
-        table.insert(t, str)
-    end
-    return t
+    return vim.split(inputstr, sep, {trimempty = true})
 end
 
 function M.get_env()


### PR DESCRIPTION
## 📃 Summary

Resolves #25 by displaying the username instead of the alias if it is not set. Also includes some minor updates:

- Fixes bug with debug logging on startup
- Use `vim.split` instead of custom split

## 📸 Preview

<img width="911" alt="Screenshot 2024-03-23 at 8 33 46 PM" src="https://github.com/jonathanmorris180/salesforce.nvim/assets/63121670/b892c63d-649f-4b57-8d2c-9af4942f873d">
