### PR TITLE
Check filetype for anon execution instead of file extension

### DIFF
--- a/lua/salesforce/execute_anon.lua
+++ b/lua/salesforce/execute_anon.lua
@@ -16,38 +16,56 @@ end
 local M = {}
 
 M.execute_anon = function()
-    Debug:log("execute_anon.lua", "Executing anonymous Apex script......")
+    Debug:log("execute_anon.lua", "Executing anonymous Apex script...")
+    local disallowed_extensions = { "cls", "trigger" }
     local path = vim.fn.expand("%:p")
+    local extension = vim.fn.expand("%:e")
     local file_type = vim.bo.filetype
     local default_username = OrgManager:get_default_username()
+    local file_contents = ""
+    local is_unsaved_buffer = false
 
-    if file_type == "apex" then
-        if path == "" then
-            Debug:log("execute_anon.lua", "Executing anonymous Apex script for current buffer...")
-            path = vim.fn.expand("%")
-            if not default_username then
-                Util.notify_default_org_not_set()
-                return
-            end
-        else
-            Debug:log("execute_anon.lua", "Executing anonymous Apex script for file...")
+    if file_type == "apex" and not vim.tbl_contains(disallowed_extensions, extension) then
+        if vim.fn.empty(path) == 1 then
+            Debug:log("execute_anon.lua", "File path is empty, retrieving buffer contents...")
+            is_unsaved_buffer = true
+            local bufnr = vim.api.nvim_get_current_buf()
+            local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+            file_contents = vim.fn.join(lines, "\n")
         end
     else
-        local message = "Not an Apex script file"
+        local message = "Not a valid Apex script"
         Debug:log("execute_anon.lua", message)
         vim.notify(message, vim.log.levels.ERROR)
+        return
+    end
+
+    if not default_username then
+        Util.notify_default_org_not_set()
         return
     end
 
     Popup:create_popup({})
     Popup:write_to_popup("Executing anonymous Apex script...")
     local executable = Config:get_options().sf_executable
-    local command = string.format("%s apex run -f '%s' -o %s", executable, path, default_username)
-    Debug:log("execute_anon.lua", "Running " .. command .. "...")
+    local args = {}
+    local writer = nil
+    if not is_unsaved_buffer then
+        args = { "apex", "run", "-f", path, "-o", default_username }
+        local command =
+            string.format("%s apex run -f '%s' -o %s", executable, path, default_username)
+        Debug:log("execute_anon.lua", "Running " .. command .. "...")
+    else
+        writer = file_contents
+        args = { "apex", "run", "-o", default_username }
+        local command = string.format("%s apex run -o %s", executable, default_username)
+        Debug:log("execute_anon.lua", "Piping unsaved buffer contents into " .. command .. "...")
+    end
     local new_job = Job:new({
         command = executable,
         env = Util.get_env(),
-        args = { "apex", "run", "-f", path, "-o", default_username },
+        args = args,
+        writer = writer,
         on_exit = function(j, code)
             vim.schedule(function()
                 if code == 0 then
@@ -63,9 +81,11 @@ M.execute_anon = function()
         on_stderr = function(_, data)
             vim.schedule(function()
                 Debug:log("execute_anon.lua", "Command stderr is: %s", data)
-                local trimmed_data = vim.trim(data)
-                if string.len(trimmed_data) > 0 then
-                    Popup:write_to_popup(data)
+                if data then
+                    local trimmed_data = vim.trim(data)
+                    if string.len(trimmed_data) > 0 then
+                        Popup:write_to_popup(data)
+                    end
                 end
             end)
         end,

--- a/lua/salesforce/execute_anon.lua
+++ b/lua/salesforce/execute_anon.lua
@@ -18,7 +18,7 @@ local M = {}
 M.execute_anon = function()
     Debug:log("execute_anon.lua", "Executing anonymous Apex script...")
     local path = vim.fn.expand("%:p")
-    local file_type = vim.fn.expand("%:e")
+    local file_type = vim.bo.filetype
     local default_username = OrgManager:get_default_username()
 
     if file_type ~= "apex" then

--- a/lua/salesforce/execute_anon.lua
+++ b/lua/salesforce/execute_anon.lua
@@ -21,15 +21,21 @@ M.execute_anon = function()
     local file_type = vim.bo.filetype
     local default_username = OrgManager:get_default_username()
 
-    if file_type ~= "apex" then
+    if file_type == "apex" then
+        if path == "" then
+            Debug:log("execute_anon.lua", "Executing anonymous Apex script for current buffer...")
+            path = vim.fn.expand("%")
+            if not default_username then
+                Util.notify_default_org_not_set()
+                return
+            end
+        else
+            Debug:log("execute_anon.lua", "Executing anonymous Apex script for file...")
+        end
+    else
         local message = "Not an Apex script file"
         Debug:log("execute_anon.lua", message)
         vim.notify(message, vim.log.levels.ERROR)
-        return
-    end
-
-    if not default_username then
-        Util.notify_default_org_not_set()
         return
     end
 

--- a/lua/salesforce/execute_anon.lua
+++ b/lua/salesforce/execute_anon.lua
@@ -16,7 +16,7 @@ end
 local M = {}
 
 M.execute_anon = function()
-    Debug:log("execute_anon.lua", "Executing anonymous Apex script...")
+    Debug:log("execute_anon.lua", "Executing anonymous Apex script......")
     local path = vim.fn.expand("%:p")
     local file_type = vim.bo.filetype
     local default_username = OrgManager:get_default_username()


### PR DESCRIPTION
## 📃 Summary

The current implementation checks an anonymous buffer for the extension: 'apex'. Only in this case its possible to run the current buffer in an anonymous execution.  It makes more sense to check if the filetype is 'apex' since its not necessary to save a file for anonymous execution

## 📸 Preview

No visual impact
