### PR TITLE
Pull executable from $PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,6 @@ require("salesforce").setup({
     org_manager = {
         default_org_indicator = "󰄬",
     },
-    -- Default SF CLI executable (should not need to be changed)
-    sf_executable = "sf",
 })
 ```
 

--- a/doc/salesforce.txt
+++ b/doc/salesforce.txt
@@ -47,8 +47,6 @@ You can pass in a lua table of options to customize the plugin. The default opti
     org_manager = {
         default_org_indicator = "󰄬",
     },
-    -- Default SF CLI executable (should not need to be changed)
-    sf_executable = "sf",
 }
 <
 

--- a/lua/salesforce/config.lua
+++ b/lua/salesforce/config.lua
@@ -24,13 +24,7 @@ function Config:new()
         org_manager = {
             default_org_indicator = "󰄬",
         },
-        -- Default SF CLI executable (should not need to be changed)
-        sf_executable = "sf",
     }
-
-    if jit.os == "Windows" then
-        o.options.sf_executable = "sf.cmd"
-    end
 
     return o
 end

--- a/lua/salesforce/diff.lua
+++ b/lua/salesforce/diff.lua
@@ -2,7 +2,6 @@ local Util = require("salesforce.util")
 local Job = require("plenary.job")
 local Debug = require("salesforce.debug")
 local OrgManager = require("salesforce.org_manager")
-local Config = require("salesforce.config")
 
 function Job:is_running()
     if self.handle and not vim.loop.is_closing(self.handle) and vim.loop.is_active(self.handle) then
@@ -15,7 +14,7 @@ end
 local M = {}
 
 local temp_dir
-local executable = Config:get_options().sf_executable
+local executable = Util.get_sf_executable()
 
 local function diff_callback(j)
     vim.schedule(function()

--- a/lua/salesforce/execute_anon.lua
+++ b/lua/salesforce/execute_anon.lua
@@ -3,7 +3,6 @@ local Debug = require("salesforce.debug")
 local OrgManager = require("salesforce.org_manager")
 local Job = require("plenary.job")
 local Util = require("salesforce.util")
-local Config = require("salesforce.config")
 
 function Job:is_running()
     if self.handle and not vim.loop.is_closing(self.handle) and vim.loop.is_active(self.handle) then
@@ -35,7 +34,7 @@ M.execute_anon = function()
 
     Popup:create_popup({})
     Popup:write_to_popup("Executing anonymous Apex script...")
-    local executable = Config:get_options().sf_executable
+    local executable = Util.get_sf_executable()
     local command = string.format("%s apex run -f '%s' -o %s", executable, path, default_username)
     Debug:log("execute_anon.lua", "Running " .. command .. "...")
     local new_job = Job:new({

--- a/lua/salesforce/file_manager.lua
+++ b/lua/salesforce/file_manager.lua
@@ -14,7 +14,7 @@ end
 
 local M = {}
 
-local executable = Config:get_options().sf_executable
+local executable = Util.get_sf_executable()
 local active_file_path = nil
 
 local function push_to_org_callback(j)

--- a/lua/salesforce/init.lua
+++ b/lua/salesforce/init.lua
@@ -43,8 +43,6 @@
 ---     org_manager = {
 ---         default_org_indicator = "󰄬",
 ---     },
----     -- Default SF CLI executable (should not need to be changed)
----     sf_executable = "sf",
 --- }
 --- <
 local Config = require("salesforce.config")

--- a/lua/salesforce/org_manager.lua
+++ b/lua/salesforce/org_manager.lua
@@ -14,7 +14,7 @@ function Job:is_running()
 end
 
 local OrgManager = {}
-local executable = Config:get_options().sf_executable
+local executable = Util.get_sf_executable()
 
 function OrgManager:new()
     local o = {}

--- a/lua/salesforce/test_runner.lua
+++ b/lua/salesforce/test_runner.lua
@@ -4,9 +4,8 @@ local OrgManager = require("salesforce.org_manager")
 local Debug = require("salesforce.debug")
 local Treesitter = require("salesforce.treesitter")
 local Util = require("salesforce.util")
-local Config = require("salesforce.config")
 
-local executable = Config:get_options().sf_executable
+local executable = Util.get_sf_executable()
 local run_class_command = executable .. ' apex run test -n "%s" --synchronous -r human -o %s'
 local run_method_command = executable .. ' apex run test -t "%s.%s" --synchronous -r human -o %s'
 

--- a/lua/salesforce/util.lua
+++ b/lua/salesforce/util.lua
@@ -158,4 +158,8 @@ function M.clear_error_diagnostics()
     vim.diagnostic.reset(namespace, bufnr)
 end
 
+function M.get_sf_executable()
+    return vim.fn.fnamemodify(vim.fn.exepath("sf"), ":t")
+end
+
 return M


### PR DESCRIPTION
## 📃 Summary

Resolves #40. This PR removes the ability to set the `sf_executable` in the config and derives it instead from the user's `$PATH`. This is a non-breaking change as any user with `sf_executable` in their config will still be able to pull this down and experience no issues. `sf_executable` was not working as intended anyway.
