### PR TITLE
Fix stderr handling in test_runner.lua

### DIFF
--- a/lua/salesforce/test_runner.lua
+++ b/lua/salesforce/test_runner.lua
@@ -56,6 +56,9 @@ local function execute_job(command)
         on_stderr = function(_, data)
             vim.schedule(function()
                 Debug:log("test_runner.lua", "Command stderr is: %s", data)
+                if not data then
+                    return
+                end
                 local trimmed_data = vim.trim(data)
                 if string.len(trimmed_data) > 0 then
                     Popup:write_to_popup(data)


### PR DESCRIPTION
## 📃 Summary

`vim.trim` errors if the input is `nil`, which resulted in errors like the following:

```txt
Error executing vim.schedule lua callback: vim/shared.lua:0: s: expected string, got nil
stack traceback:
        [C]: in function 'error'
        vim/shared.lua: in function 'validate'
        vim/shared.lua: in function 'trim'
        ...nvim/lazy/salesforce.nvim/lua/salesforce/test_runner.lua:59: in function <...nvim/lazy/salesforce.nvim/lua/salesforce/test_runner.lua:57>
```